### PR TITLE
Rename apply; add both; rework docs

### DIFF
--- a/src/Function/Extra.elm
+++ b/src/Function/Extra.elm
@@ -1,4 +1,5 @@
-module Function.Extra where
+module Function.Extra (..) where
+
 {-| Higher-order helpers for working with functions.
 
 # Higher-order helpers
@@ -10,6 +11,7 @@ module Function.Extra where
 
 -}
 
+
 {-| Map into a function with a fixed input `x`. This function is just an alias for `(<<)`, the function composition operator.
 
     (f `map` g `map` h) == (f << g << h) -- Note that `map` refers to Function.map not List.map!
@@ -18,7 +20,9 @@ The `(x -> ...)` signature is sometimes refered to as a *"reader"* of `x`, where
 This allows `map` to transform a *"reader"* that produces an `a` into a *"reader"* that produces a `b`.
 -}
 map : (a -> b) -> (x -> a) -> x -> b
-map = (<<)
+map =
+  (<<)
+
 
 {-| Send a single argument `x` into a binary function using two intermediate mappings.
 
@@ -28,7 +32,9 @@ The `(x -> ...)` signatures are sometimes refered to as *"readers"* of `x`, wher
 This allows `map2` to read two variables from the environment `x` before applying them to a binary function `f`.
 -}
 map2 : (a -> b -> c) -> (x -> a) -> (x -> b) -> x -> c
-map2 f ga gb x = f (ga x) (gb x)
+map2 f ga gb x =
+  f (ga x) (gb x)
+
 
 {-| Send a single argument `x` into a ternary function using three intermediate mappings.
 
@@ -38,7 +44,9 @@ The `(x -> ...)` signatures are sometimes refered to as *"readers"* of `x`, wher
 This allows `map3` to read three variables from the environment `x` before applying them to a ternary function `f`.
 -}
 map3 : (a -> b -> c -> d) -> (x -> a) -> (x -> b) -> (x -> c) -> x -> d
-map3 f ga gb gc x = f (ga x) (gb x) (gc x)
+map3 f ga gb gc x =
+  f (ga x) (gb x) (gc x)
+
 
 {-| Send a single argument `x` into a quaternary function using four intermediate mappings.
 Use `apply` as an infix combinator in order to deal with a larger numbers of arguments.
@@ -49,7 +57,9 @@ The `(x -> ...)` signatures are sometimes refered to as *"readers"* of `x`, wher
 This allows `map4` to read four variables from the environment `x` before applying them to a quaternary function `f`.
 -}
 map4 : (a -> b -> c -> d -> e) -> (x -> a) -> (x -> b) -> (x -> c) -> (x -> d) -> x -> e
-map4 f ga gb gc gd x = f (ga x) (gb x) (gc x) (gd x)
+map4 f ga gb gc gd x =
+  f (ga x) (gb x) (gc x) (gd x)
+
 
 {-| Incrementally apply more functions, similar to `map`*N* where *N* is not fixed.
 
@@ -81,7 +91,9 @@ Also notice the type signatures...
 
 -}
 apply : (x -> a -> b) -> (x -> a) -> x -> b
-apply f ga x = f x (ga x)
+apply f ga x =
+  f x (ga x)
+
 
 {-| Connect the result `a` of the first function to the first argument of the second function to form a pipeline.
 Then, send `x` into each function along the pipeline in order to execute it in a sequential manner.
@@ -92,43 +104,57 @@ This allows `andThen` to repeatedly read from the environment `x` and send the r
     (f `andThen` g `andThen` h) x == (h (g (f x) x) x)
 -}
 andThen : (x -> a) -> (a -> x -> b) -> x -> b
-andThen fa g x = g (fa x) x
+andThen fa g x =
+  g (fa x) x
+
 
 {-| Change how arguments are passed to a function.
 This splits 3-tupled arguments into three separate arguments.
 -}
-curry3 : ((a,b,c) -> x) -> a -> b -> c -> x
-curry3 f a b c = f (a,b,c)
+curry3 : (( a, b, c ) -> x) -> a -> b -> c -> x
+curry3 f a b c =
+  f ( a, b, c )
+
 
 {-| Change how arguments are passed to a function.
 This splits 4-tupled arguments into four separate arguments.
 -}
-curry4 : ((a,b,c,d) -> x) -> a -> b -> c -> d -> x
-curry4 f a b c d = f (a,b,c,d)
+curry4 : (( a, b, c, d ) -> x) -> a -> b -> c -> d -> x
+curry4 f a b c d =
+  f ( a, b, c, d )
+
 
 {-| Change how arguments are passed to a function.
 This splits 5-tupled arguments into five separate arguments.
 -}
-curry5 : ((a,b,c,d,e) -> x) -> a -> b -> c -> d -> e -> x
-curry5 f a b c d e = f (a,b,c,d,e)
+curry5 : (( a, b, c, d, e ) -> x) -> a -> b -> c -> d -> e -> x
+curry5 f a b c d e =
+  f ( a, b, c, d, e )
+
 
 {-| Change how arguments are passed to a function.
 This combines three arguments into a single 3-tuple.
 -}
-uncurry3 : (a -> b -> c -> x) -> (a,b,c) -> x
-uncurry3 f (a,b,c) = f a b c
+uncurry3 : (a -> b -> c -> x) -> ( a, b, c ) -> x
+uncurry3 f ( a, b, c ) =
+  f a b c
+
 
 {-| Change how arguments are passed to a function.
 This combines four arguments into a single 4-tuple.
 -}
-uncurry4 : (a -> b -> c -> d -> x) -> (a,b,c,d) -> x
-uncurry4 f (a,b,c,d) = f a b c d
+uncurry4 : (a -> b -> c -> d -> x) -> ( a, b, c, d ) -> x
+uncurry4 f ( a, b, c, d ) =
+  f a b c d
+
 
 {-| Change how arguments are passed to a function.
 This combines five arguments into a single 5-tuple.
 -}
-uncurry5 : (a -> b -> c -> d -> e -> x) -> (a,b,c,d,e) -> x
-uncurry5 f (a,b,c,d,e) = f a b c d e
+uncurry5 : (a -> b -> c -> d -> e -> x) -> ( a, b, c, d, e ) -> x
+uncurry5 f ( a, b, c, d, e ) =
+  f a b c d e
+
 
 {-| Apply a binary function using a transformation on both input parameters.
 
@@ -136,4 +162,5 @@ uncurry5 f (a,b,c,d,e) = f a b c d e
     sortBy (compare `on` fst) == sortBy (\x y -> fst x `compare` fst y)
 -}
 on : (b -> b -> c) -> (a -> b) -> a -> a -> c
-on bi f x y = f x `bi` f y
+on bi f x y =
+  f x `bi` f y

--- a/src/Function/Extra.elm
+++ b/src/Function/Extra.elm
@@ -35,73 +35,73 @@ map =
 
 {-| Send a single argument `x` into a binary function using two intermediate mappings.
 
-    (map2 f ga gb) x == (f (ga x) (gb x)) x
+    (map2 f ra rb) x == (f (ra x) (rb x)) x
 
 This allows `map2` to read two variables from the environment `x` before applying them to a binary function `f`.
 -}
 map2 : (a -> b -> c) -> (x -> a) -> (x -> b) -> x -> c
-map2 f ga gb x =
-  f (ga x) (gb x)
+map2 f ra rb x =
+  f (ra x) (rb x)
 
 
 {-| Send a single argument `x` into a ternary function using three intermediate mappings.
 
-    (map3 f ga gb gc) x == (f (ga x) (gb x) (gc x)) x
+    (map3 f ra rb rc) x == (f (ra x) (rb x) (rc x)) x
 
 This allows `map3` to read three variables from the environment `x` before applying them to a ternary function `f`.
 -}
 map3 : (a -> b -> c -> d) -> (x -> a) -> (x -> b) -> (x -> c) -> x -> d
-map3 f ga gb gc x =
-  f (ga x) (gb x) (gc x)
+map3 f ra rb rc x =
+  f (ra x) (rb x) (rc x)
 
 
 {-| Send a single argument `x` into a quaternary function using four intermediate mappings.
 Use `andMap` as an infix combinator in order to deal with a larger numbers of arguments.
 
-    (map4 f ga gb gc gd) x == (f (ga x) (gb x) (gc x) (gd x)) x
+    (map4 f ra rb rc gd) x == (f (ra x) (rb x) (rc x) (gd x)) x
 
 This allows `map4` to read four variables from the environment `x` before applying them to a quaternary function `f`.
 -}
 map4 : (a -> b -> c -> d -> e) -> (x -> a) -> (x -> b) -> (x -> c) -> (x -> d) -> x -> e
-map4 f ga gb gc gd x =
-  f (ga x) (gb x) (gc x) (gd x)
+map4 f ra rb rc gd x =
+  f (ra x) (rb x) (rc x) (gd x)
 
 
 {-| Incrementally apply more functions, similar to `map`*N* where *N* is not fixed. This allows `andMap` to read an arbitrary number of arguments from the same environment `x`.
 
 These are all equivalent:
 
-    (f `andMap` ga `andMap` gb `andMap` gc) x
-    f x (ga x) (gb x) (gc x)
-    (map4 identity f ga gb gc) x
-    (identity `map` f `andMap` ga `andMap` gb `andMap` gc) x
+    (f `andMap` ra `andMap` rb `andMap` rc) x
+    f x (ra x) (rb x) (rc x)
+    (map4 identity f ra rb rc) x
+    (identity `map` f `andMap` ra `andMap` rb `andMap` rc) x
 
 As are all of these:
 
-    (f' `map` ga `andMap` gb `andMap` gc) x
-    f' (ga x) (gb x) (gc x) x
-    (map3 f' ga gb gc) x
+    (f' `map` ra `andMap` rb `andMap` rc) x
+    f' (ra x) (rb x) (rc x) x
+    (map3 f' ra rb rc) x
 
 Also notice the type signatures...
 
-    ga                                      : x -> a
-    gb                                      : x -> b
-    gc                                      : x -> c
+    ra                                      : x -> a
+    rb                                      : x -> b
+    rc                                      : x -> c
 
     f                                       : x -> a -> b -> c -> d
-    (f `andMap` ga)                         : x -> b -> c -> d
-    (f `andMap` ga `andMap` gb)             : x -> c -> d
-    (f `andMap` ga `andMap` gb `andMap` gc) : x -> d
+    (f `andMap` ra)                         : x -> b -> c -> d
+    (f `andMap` ra `andMap` rb)             : x -> c -> d
+    (f `andMap` ra `andMap` rb `andMap` rc) : x -> d
 
     f'                                      : a -> b -> c -> d
-    (f' `map` ga)                           : x -> b -> c -> d
-    (f' `map` ga `andMap` gb)               : x -> c -> d
-    (f' `map` ga `andMap` gb `andMap` gc)   : x -> d
+    (f' `map` ra)                           : x -> b -> c -> d
+    (f' `map` ra `andMap` rb)               : x -> c -> d
+    (f' `map` ra `andMap` rb `andMap` rc)   : x -> d
 
 -}
 andMap : (x -> a -> b) -> (x -> a) -> x -> b
-andMap f ga x =
-  f x (ga x)
+andMap f ra x =
+  f x (ra x)
 
 
 {-| Connect the result `a` of the first function to the first argument of the second function to form a pipeline.

--- a/src/Function/Extra.elm
+++ b/src/Function/Extra.elm
@@ -23,7 +23,8 @@ function needs. We can map over readers similar to how we do for lists.
 
 {-| Map into a function with a fixed input `x`. This function is just an alias for `(<<)`, the function composition operator.
 
-    (f `map` g `map` h) == (f << g << h) -- Note that `map` refers to Function.map not List.map!
+    -- Note that `map` refers to Function.map not List.map!
+    (f `map` g `map` h) == (f << g << h)
 
 This allows `map` to transform a *"reader"* that produces an `a` into a *"reader"* that produces a `b`.
 -}
@@ -66,17 +67,20 @@ map4 f ga gb gc gd x =
   f (ga x) (gb x) (gc x) (gd x)
 
 
-{-| Incrementally apply more functions, similar to `map`*N* where *N* is not fixed.
+{-| Incrementally apply more functions, similar to `map`*N* where *N* is not fixed. This allows `andMap` to read an arbitrary number of arguments from the same environment `x`.
 
-The `(x -> ...)` signature is sometimes refered to as a *"reader"* of `x`, where `x` represents some ancillary environment within which we would like to operate.
-This allows `andMap` to read an arbitrary number of arguments from the same environment `x`.
+These are all equivalent:
 
-    (f `andMap` ga `andMap` gb `andMap` gc) x == f x (ga x) (gb x) (gc x)
-                                           == (map4 identity f ga gb gc) x
-                                           == (identity `map` f `andMap` ga `andMap` gb `andMap` gc) x
+    (f `andMap` ga `andMap` gb `andMap` gc) x
+    f x (ga x) (gb x) (gc x)
+    (map4 identity f ga gb gc) x
+    (identity `map` f `andMap` ga `andMap` gb `andMap` gc) x
 
-    (f' `map` ga `andMap` gb `andMap` gc) x  == f' (ga x) (gb x) (gc x) x
-                                           == (map3 f' ga gb gc) x
+As are all of these:
+
+    (f' `map` ga `andMap` gb `andMap` gc) x
+    f' (ga x) (gb x) (gc x) x
+    (map3 f' ga gb gc) x
 
 Also notice the type signatures...
 


### PR DESCRIPTION
This PR includes a number of what I consider to be improvements, but I'm expecting some feedback.

* Ran `elm-format`
* Renamed `apply` to `andMap`. This convention is established in core/Task and many third-party libraries.
* Added `both : (a -> b) -> ( a, a ) -> ( b, b )`. I've written this a few times before and thought I'd throw it in. Arguably there should be versions for larger tuples, in a `thingN` pattern.
* Organized the docs. Tried to make them less "Haskelly". Also previewed them and fixed some issues with linewrap etc.
* Renamed `ga`, `gb` etc to `ra`, `rb` because these are *readers* of a, b.